### PR TITLE
fix: initialize wave, wind and thruster with values

### DIFF
--- a/src/Thruster.hpp
+++ b/src/Thruster.hpp
@@ -19,9 +19,9 @@ namespace gazebo_usv {
         std::string name;
         size_t actuator_id;
         gazebo::physics::LinkPtr link;
-        double min_thrust;
-        double max_thrust;
-        double effort;
+        double min_thrust = 0;
+        double max_thrust = 0;
+        double effort = 0;
     };
 }
 

--- a/src/Wave.hpp
+++ b/src/Wave.hpp
@@ -17,14 +17,14 @@ namespace gazebo_usv {
     public:
         // Wave force and torque
         struct Effects {
-            ignition::math::Vector3d force;
-            ignition::math::Vector3d torque;
+            ignition::math::Vector3d force = ignition::math::Vector3d::Zero;
+            ignition::math::Vector3d torque = ignition::math::Vector3d::Zero;
         };
         // Wave phases to be defined
-        double m_phase_x;
-        double m_phase_y;
-        double m_phase_z;
-        double m_phase_n;
+        double m_phase_x = 0;
+        double m_phase_y = 0;
+        double m_phase_z = 0;
+        double m_phase_n = 0;
 
         Wave() = default;
         ~Wave();
@@ -74,10 +74,10 @@ namespace gazebo_usv {
         SubscriberPtr m_wave_frequency_subscriber;
         SubscriberPtr m_roll_subscriber;
 
-        ignition::math::Vector3d m_wave_amplitude{};
-        ignition::math::Vector3d m_wave_frequency{};
-        double m_roll_amplitude;
-        double m_roll_frequency;
+        ignition::math::Vector3d m_wave_amplitude = ignition::math::Vector3d::Zero;
+        ignition::math::Vector3d m_wave_frequency = ignition::math::Vector3d::Zero;
+        double m_roll_amplitude = 0;
+        double m_roll_frequency = 0;
 
         /**
          * @brief Get the reference link where force and torque will be applied

--- a/src/Wind.hpp
+++ b/src/Wind.hpp
@@ -19,17 +19,17 @@ namespace gazebo_usv
         // Parameters used to calculate the wind effects 
         struct EffectParameters
         {
-            double frontal_area;
-            double lateral_area;
-            double length_overall;
-            double air_density;
-            ignition::math::Vector3d coefficients;
+            double frontal_area = 0;
+            double lateral_area = 0;
+            double length_overall = 0;
+            double air_density = 0;
+            ignition::math::Vector3d coefficients = ignition::math::Vector3d::Zero;
         };
         // Wind force and torque
         struct Effects
         {
-            ignition::math::Vector3d force;
-            ignition::math::Vector3d torque;
+            ignition::math::Vector3d force = ignition::math::Vector3d::Zero;
+            ignition::math::Vector3d torque = ignition::math::Vector3d::Zero;
         };
 
         Wind() = default;
@@ -80,7 +80,7 @@ namespace gazebo_usv
         SubscriberPtr m_wind_velocity_subscriber;
 
         EffectParameters m_parameters;
-        ignition::math::Vector3d m_wind_velocity{};
+        ignition::math::Vector3d m_wind_velocity = ignition::math::Vector3d::Zero;
 
         /**
          * @brief Get the reference link where force and torque will be applied


### PR DESCRIPTION
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
Sometimes the charts/vessel camera would bug and it would show a strange image as if the main camera was located inside or the vessel and the other cameras were pointing at a squared box. This fixes this error.

The source of the bug was that the wave/... parameters are initialized with subscriptions. In some cases, the simulation would run before we received the very first value, which would cause the plugin to generate absurd forces (and sometimes simply injecting NaN/Inf).

# How I did it
<!-- Explain a little bit of your implementation -->
This modification initializes wave, wind and thruster variables as zero, in doing so, it avoids the error caused when updating wave, wind and thruster values with null values which would break the simulation because of it's cascading effect on all the other functions resulting on the main camera being inside the vessel and the vessel's pose and velocity values being inf or nan and not updating unless we restarted all the simulation (UI, Syskit IDE and Rock-Gazebo).

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
