### PR TITLE
fix: link name was unable to find the thruster link

### DIFF
--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -73,22 +73,12 @@ gazebo::physics::LinkPtr utilities::getLinkFromName(gazebo::physics::ModelPtr mo
     std::string const& link_name,
     std::string const& plugin_name)
 {
-    std::string link_name_iterated = link_name;
-    std::string plugin_name_iterated = plugin_name.substr(0, plugin_name.rfind("__"));
-    std::size_t pos = plugin_name_iterated.rfind("__");
-    std::string plugin_prefix = plugin_name_iterated.substr(pos + 2);
-    auto link = model->GetLink(link_name_iterated);
+    std::string scope = plugin_name.substr(0, plugin_name.rfind("__"));
+    std::string model_name = model->GetName();
+    std::string scope_relative_2_model = scope.substr(scope.find(model_name));
+    // Correct the separators to match the link name
+    std::string relative_scope_corrected =
+        std::regex_replace(scope_relative_2_model, std::regex("__"), "::");
 
-    while (pos != std::string::npos) {
-        if (link) {
-            break;
-        }
-        pos = plugin_name_iterated.rfind("__");
-        plugin_prefix = plugin_name_iterated.substr(pos + 2);
-        plugin_name_iterated = plugin_name_iterated.substr(0, pos);
-        link_name_iterated = plugin_prefix + "::" + link_name_iterated;
-        link = model->GetLink(link_name_iterated);
-    }
-
-    return link;
+    return model->GetLink(relative_scope_corrected + "::" + link_name);
 }


### PR DESCRIPTION

<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
The thruster link couldn't be found since the previous iteration of the code tried to find the value by
brute forcing searches until a link was found however it also did the first iteration from the full name twice on the first run which resulted on it being unable to find the thruster model on one of our sdfs. To avoid this behaviour, now the getLinkFromName searches for a single link name, removing the brute force behaviour.

# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [ ] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
